### PR TITLE
Highlight available workers for selected card when worker is no longer busy

### DIFF
--- a/script.js
+++ b/script.js
@@ -696,6 +696,7 @@ function personFree(person) {
         log("Will check board in " + delay);
         setTimeout(function () { selfStart(person); }, delay);
     }
+    updatePossible();
 }
 function selfStart(person) {
     //Now I will go and see if there are any cards on the board that I believe are worthy of my attention.

--- a/script.ts
+++ b/script.ts
@@ -934,6 +934,7 @@ function personFree(person:Person) {
     log(`Will check board in ${delay}`);
     setTimeout(function() { selfStart(person);}, delay);
   }
+  updatePossible();
 }
 
 function selfStart(person:Person){


### PR DESCRIPTION
This PR makes it so that whenever a card is selected and a matching worker that was busy becomes free, they get properly marked as `possible` for the selected card.

I know you said "pull requests _not_ welcome", but I couldn't resist seeing how quickly I could read through your code and fix this little 🐛. 😬 

The code overall is very legible and understandable! Fun stuff! Good luck with the project!